### PR TITLE
Keepcalm and carry on inserting

### DIFF
--- a/pmacct/src/mongodb_plugin.c
+++ b/pmacct/src/mongodb_plugin.c
@@ -788,7 +788,7 @@ void MongoDB_cache_purge(struct chained_cache *queue[], int index)
         else db_status = mongo_insert_batch(&db_conn, config.sql_table, bson_batch, batch_idx, NULL, MONGO_CONTINUE_ON_ERROR);
         if (db_status != MONGO_OK) {
   	  Log(LOG_ERR, "ERROR ( %s/%s ): Unable to insert all elements in batch: try a smaller mongo_insert_batch value.\n", config.name, config.type);
-          Log(LOG_ERR, "ERROR ( %s/%s ): Error: %s.\n", config.name, config.type, db_conn->lasterrstr);
+          Log(LOG_ERR, "ERROR ( %s/%s ): Error: %s.\n", config.name, config.type, db_conn.lasterrstr);
         }
 
         for (i = 0; i < batch_idx; i++) {
@@ -808,7 +808,7 @@ void MongoDB_cache_purge(struct chained_cache *queue[], int index)
     else db_status = mongo_insert_batch(&db_conn, config.sql_table, bson_batch, batch_idx, NULL, MONGO_CONTINUE_ON_ERROR);
     if (db_status != MONGO_OK) {
       Log(LOG_ERR, "ERROR ( %s/%s ): Unable to insert all elements in batch: try a smaller mongo_insert_batch value.\n", config.name, config.type);
-      Log(LOG_ERR, "ERROR ( %s/%s ): Error: %s.\n", config.name, config.type, db_conn->lasterrstr);
+      Log(LOG_ERR, "ERROR ( %s/%s ): Error: %s.\n", config.name, config.type, db_conn.lasterrstr);
     }
 
     for (i = 0; i < batch_idx; i++) {

--- a/pmacct/src/mongodb_plugin.c
+++ b/pmacct/src/mongodb_plugin.c
@@ -786,9 +786,11 @@ void MongoDB_cache_purge(struct chained_cache *queue[], int index)
       if (batch_idx == config.mongo_insert_batch) {
         if (dyn_table) db_status = mongo_insert_batch(&db_conn, current_table, bson_batch, batch_idx, NULL, MONGO_CONTINUE_ON_ERROR);
         else db_status = mongo_insert_batch(&db_conn, config.sql_table, bson_batch, batch_idx, NULL, MONGO_CONTINUE_ON_ERROR);
-        if (db_status != MONGO_OK)
+        if (db_status != MONGO_OK) {
   	  Log(LOG_ERR, "ERROR ( %s/%s ): Unable to insert all elements in batch: try a smaller mongo_insert_batch value.\n", config.name, config.type);
-  
+          Log(LOG_ERR, "ERROR ( %s/%s ): Error: %s.\n", config.name, config.type, db_conn->lasterrstr);
+        }
+
         for (i = 0; i < batch_idx; i++) {
           bson_elem = (bson *) bson_batch[i];
           bson_destroy(bson_elem);
@@ -804,8 +806,10 @@ void MongoDB_cache_purge(struct chained_cache *queue[], int index)
   if (batch_idx) {
     if (dyn_table) db_status = mongo_insert_batch(&db_conn, current_table, bson_batch, batch_idx, NULL, MONGO_CONTINUE_ON_ERROR);
     else db_status = mongo_insert_batch(&db_conn, config.sql_table, bson_batch, batch_idx, NULL, MONGO_CONTINUE_ON_ERROR);
-    if (db_status != MONGO_OK) 
+    if (db_status != MONGO_OK) {
       Log(LOG_ERR, "ERROR ( %s/%s ): Unable to insert all elements in batch: try a smaller mongo_insert_batch value.\n", config.name, config.type);
+      Log(LOG_ERR, "ERROR ( %s/%s ): Error: %s.\n", config.name, config.type, db_conn->lasterrstr);
+    }
 
     for (i = 0; i < batch_idx; i++) {
       bson_elem = (bson *) bson_batch[i];

--- a/pmacct/src/mongodb_plugin.c
+++ b/pmacct/src/mongodb_plugin.c
@@ -300,9 +300,9 @@ void MongoDB_cache_purge(struct chained_cache *queue[], int index)
   }
 
   if (config.sql_host)
-    db_status = mongo_connect(&db_conn, config.sql_host, 27017 /* default port */);
+    db_status = mongo_client(&db_conn, config.sql_host, 27017 /* default port */);
   else
-    db_status = mongo_connect(&db_conn, "127.0.0.1", 27017 /* default port */);
+    db_status = mongo_client(&db_conn, "127.0.0.1", 27017 /* default port */);
 
   if (db_status != MONGO_OK) {
     switch (db_conn.err) {

--- a/pmacct/src/mongodb_plugin.c
+++ b/pmacct/src/mongodb_plugin.c
@@ -802,8 +802,8 @@ void MongoDB_cache_purge(struct chained_cache *queue[], int index)
 
   /* last round on the lollipop */
   if (batch_idx) {
-    if (dyn_table) db_status = mongo_insert_batch(&db_conn, current_table, bson_batch, batch_idx, NULL, 0);
-    else db_status = mongo_insert_batch(&db_conn, config.sql_table, bson_batch, batch_idx, NULL, 0);
+    if (dyn_table) db_status = mongo_insert_batch(&db_conn, current_table, bson_batch, batch_idx, NULL, MONGO_CONTINUE_ON_ERROR););
+    else db_status = mongo_insert_batch(&db_conn, config.sql_table, bson_batch, batch_idx, NULL, MONGO_CONTINUE_ON_ERROR););
     if (db_status != MONGO_OK) 
       Log(LOG_ERR, "ERROR ( %s/%s ): Unable to insert all elements in batch: try a smaller mongo_insert_batch value.\n", config.name, config.type);
 

--- a/pmacct/src/mongodb_plugin.c
+++ b/pmacct/src/mongodb_plugin.c
@@ -788,7 +788,8 @@ void MongoDB_cache_purge(struct chained_cache *queue[], int index)
         else db_status = mongo_insert_batch(&db_conn, config.sql_table, bson_batch, batch_idx, NULL, MONGO_CONTINUE_ON_ERROR);
         if (db_status != MONGO_OK) {
   	  Log(LOG_ERR, "ERROR ( %s/%s ): Unable to insert all elements in batch: try a smaller mongo_insert_batch value.\n", config.name, config.type);
-          Log(LOG_ERR, "ERROR ( %s/%s ): Error: %s.\n", config.name, config.type, db_conn.lasterrstr);
+          Log(LOG_ERR, "ERROR ( %s/%s ): Server error: %s. (PID: %d, QN: %d/%d)\n",
+              config.name, config.type, db_conn.lasterrstr, writer_pid, qn, saved_index);
         }
 
         for (i = 0; i < batch_idx; i++) {
@@ -808,7 +809,8 @@ void MongoDB_cache_purge(struct chained_cache *queue[], int index)
     else db_status = mongo_insert_batch(&db_conn, config.sql_table, bson_batch, batch_idx, NULL, MONGO_CONTINUE_ON_ERROR);
     if (db_status != MONGO_OK) {
       Log(LOG_ERR, "ERROR ( %s/%s ): Unable to insert all elements in batch: try a smaller mongo_insert_batch value.\n", config.name, config.type);
-      Log(LOG_ERR, "ERROR ( %s/%s ): Error: %s.\n", config.name, config.type, db_conn.lasterrstr);
+      Log(LOG_ERR, "ERROR ( %s/%s ): Server error: %s. (PID: %d, QN: %d/%d)\n",
+          config.name, config.type, db_conn.lasterrstr, writer_pid, qn, saved_index);
     }
 
     for (i = 0; i < batch_idx; i++) {

--- a/pmacct/src/mongodb_plugin.c
+++ b/pmacct/src/mongodb_plugin.c
@@ -802,8 +802,8 @@ void MongoDB_cache_purge(struct chained_cache *queue[], int index)
 
   /* last round on the lollipop */
   if (batch_idx) {
-    if (dyn_table) db_status = mongo_insert_batch(&db_conn, current_table, bson_batch, batch_idx, NULL, MONGO_CONTINUE_ON_ERROR););
-    else db_status = mongo_insert_batch(&db_conn, config.sql_table, bson_batch, batch_idx, NULL, MONGO_CONTINUE_ON_ERROR););
+    if (dyn_table) db_status = mongo_insert_batch(&db_conn, current_table, bson_batch, batch_idx, NULL, MONGO_CONTINUE_ON_ERROR);
+    else db_status = mongo_insert_batch(&db_conn, config.sql_table, bson_batch, batch_idx, NULL, MONGO_CONTINUE_ON_ERROR);
     if (db_status != MONGO_OK) 
       Log(LOG_ERR, "ERROR ( %s/%s ): Unable to insert all elements in batch: try a smaller mongo_insert_batch value.\n", config.name, config.type);
 

--- a/pmacct/src/mongodb_plugin.c
+++ b/pmacct/src/mongodb_plugin.c
@@ -784,8 +784,8 @@ void MongoDB_cache_purge(struct chained_cache *queue[], int index)
       if (config.debug) bson_print(bson_elem);
   
       if (batch_idx == config.mongo_insert_batch) {
-        if (dyn_table) db_status = mongo_insert_batch(&db_conn, current_table, bson_batch, batch_idx, NULL, 0);
-        else db_status = mongo_insert_batch(&db_conn, config.sql_table, bson_batch, batch_idx, NULL, 0);
+        if (dyn_table) db_status = mongo_insert_batch(&db_conn, current_table, bson_batch, batch_idx, NULL, MONGO_CONTINUE_ON_ERROR);
+        else db_status = mongo_insert_batch(&db_conn, config.sql_table, bson_batch, batch_idx, NULL, MONGO_CONTINUE_ON_ERROR);
         if (db_status != MONGO_OK)
   	  Log(LOG_ERR, "ERROR ( %s/%s ): Unable to insert all elements in batch: try a smaller mongo_insert_batch value.\n", config.name, config.type);
   

--- a/pmacct/src/mongodb_plugin.c
+++ b/pmacct/src/mongodb_plugin.c
@@ -135,6 +135,7 @@ void mongodb_plugin(int pipe_fd, struct configuration *cfgptr, void *ptr)
 
   mongo_init(&db_conn);
   mongo_set_op_timeout(&db_conn, 1000);
+  bson_set_oid_fuzz(&mongodb_oid_fuzz);
 
   /* plugin main loop */
   for(;;) {
@@ -893,4 +894,13 @@ void MongoDB_append_label(bson *bson_elem, char *name, struct pkt_vlen_hdr_primi
   vlen_prims_get(pvlen, wtc, &label_ptr);
   if (label_ptr) bson_append_string(bson_elem, name, label_ptr); 
   else bson_append_null(bson_elem, name);
+}
+
+int mongodb_oid_fuzz(void)
+{
+  struct timeval now;
+  gettimeofday(&now, NULL);
+  srand((int)now.tv_usec);
+
+  return rand();
 }

--- a/pmacct/src/mongodb_plugin.h
+++ b/pmacct/src/mongodb_plugin.h
@@ -20,7 +20,9 @@
 */
 
 /* includes */
+#include <stdlib.h>
 #include <sys/poll.h>
+#include <time.h>
 
 /* defines */
 #if (!defined MONGO_HAVE_STDINT)
@@ -43,6 +45,7 @@ EXT void MongoDB_cache_purge(struct chained_cache *[], int);
 EXT void MongoDB_create_indexes(mongo *, const char *);
 EXT int MongoDB_get_database(char *, int, char *);
 EXT void MongoDB_append_label(bson *, char *, struct pkt_vlen_hdr_primitives *, pm_cfgreg_t);
+EXT int mongodb_oid_fuzz(void);
 
 /* global vars */
 EXT void (*insert_func)(struct primitives_ptrs *, struct insert_data *); /* pointer to INSERT function */


### PR DESCRIPTION
The bson oid generator in the mongo-c-driver-legacy gives very poor uniqueness.

The OID is constructed from a timestamp (1s resolution), a random fuzz factor and an increasing counter.  Turns out the fuzz is a call to rand() after the seed is set using the same timestamp.  i.e. There are two fields which both have 1s resolution, and the counter is only unique within a particular thread.

This pull request adds a fuzz_oid callback that sets the seed based on usec resolution.  There is still a chance of a clash here but it is vastly reduced from the standard algorithm.

The latest versions of the C driver incorporate the process/thread ID into the random number generator so these clashes are no longer an issue.

This patch also includes some debugging that was useful in tracking the issue down, a change to using mongo_client() rather than mongo_connect() which removes a deprecation warning and changes the default write concern from w=0 to w=1.  This PR also includes a change to use MONGO_CONTINUE_ON_ERROR for the bulk inserts so that errors only affect specific documents rather than entire batches.
